### PR TITLE
Feature: add optional and nullable rules

### DIFF
--- a/src/Commands/SkipValidationRules.php
+++ b/src/Commands/SkipValidationRules.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace StellarWP\Validation\Commands;
 
+/**
+ * Returning this command from ValidationRule::__invoke() tells the Validator to skip all subsequent rules.
+ *
+ * @unreleased
+ */
 class SkipValidationRules
 {
-
 }

--- a/src/Commands/SkipValidationRules.php
+++ b/src/Commands/SkipValidationRules.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StellarWP\Validation\Commands;
+
+class SkipValidationRules
+{
+
+}

--- a/src/Contracts/ValidationRule.php
+++ b/src/Contracts/ValidationRule.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace StellarWP\Validation\Contracts;
 
 use Closure;
+use StellarWP\Validation\Commands\SkipValidationRules;
 
 interface ValidationRule
 {
@@ -31,7 +32,7 @@ interface ValidationRule
      *
      * @unreleased
      *
-     * @return void
+     * @return void|SkipValidationRules
      */
     public function __invoke($value, Closure $fail, string $key, array $values);
 }

--- a/src/Rules/Nullable.php
+++ b/src/Rules/Nullable.php
@@ -50,6 +50,6 @@ class Nullable implements ValidationRule, ValidatesOnFrontEnd
      */
     public function serializeOption()
     {
-        // TODO: Implement serializeOption() method.
+        return null;
     }
 }

--- a/src/Rules/Nullable.php
+++ b/src/Rules/Nullable.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StellarWP\Validation\Rules;
+
+use Closure;
+use StellarWP\Validation\Commands\SkipValidationRules;
+use StellarWP\Validation\Contracts\ValidatesOnFrontEnd;
+use StellarWP\Validation\Contracts\ValidationRule;
+
+/**
+ * This rule skips further validation if the field is null. It is similar to Optional, but the only allowed value is
+ * null.
+ *
+ * @unreleased
+ */
+class Nullable implements ValidationRule, ValidatesOnFrontEnd
+{
+    /**
+     * @unreleased
+     */
+    public static function id(): string
+    {
+        return 'nullable';
+    }
+
+    /**
+     * @unreleased
+     */
+    public static function fromString(string $options = null): ValidationRule
+    {
+        return new self();
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return SkipValidationRules|void
+     */
+    public function __invoke($value, Closure $fail, string $key, array $values)
+    {
+        if ($value === null) {
+            return new SkipValidationRules();
+        }
+    }
+
+    /**
+     * @unreleased
+     */
+    public function serializeOption()
+    {
+        // TODO: Implement serializeOption() method.
+    }
+}

--- a/src/Rules/Optional.php
+++ b/src/Rules/Optional.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StellarWP\Validation\Rules;
+
+use Closure;
+use StellarWP\Validation\Commands\SkipValidationRules;
+use StellarWP\Validation\Contracts\ValidatesOnFrontEnd;
+use StellarWP\Validation\Contracts\ValidationRule;
+
+/**
+ * This rule marks a field as optional and skips further validation if the rule is either null or an empty string.
+ *
+ * @unreleased
+ */
+class Optional implements ValidationRule, ValidatesOnFrontEnd
+{
+    /**
+     * @unreleased
+     */
+    public static function id(): string
+    {
+        return 'optional';
+    }
+
+    /**
+     * @unreleased
+     */
+    public static function fromString(string $options = null): ValidationRule
+    {
+        return new self();
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return SkipValidationRules|void
+     */
+    public function __invoke($value, Closure $fail, string $key, array $values)
+    {
+        if ($value === null || $value === '') {
+            return new SkipValidationRules();
+        }
+    }
+
+    /**
+     * @unreleased
+     */
+    public function serializeOption()
+    {
+        return null;
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -9,7 +9,9 @@ use StellarWP\Validation\Rules\Email;
 use StellarWP\Validation\Rules\Integer;
 use StellarWP\Validation\Rules\Max;
 use StellarWP\Validation\Rules\Min;
+use StellarWP\Validation\Rules\Nullable;
 use StellarWP\Validation\Rules\Numeric;
+use StellarWP\Validation\Rules\Optional;
 use StellarWP\Validation\Rules\Required;
 use StellarWP\Validation\Rules\Size;
 
@@ -24,6 +26,8 @@ class ServiceProvider
         Integer::class,
         Email::class,
         Currency::class,
+        Nullable::class,
+        Optional::class,
     ];
 
     /**

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace StellarWP\Validation;
 
+use StellarWP\Validation\Commands\SkipValidationRules;
 use StellarWP\Validation\Contracts\Sanitizer;
 
 /**
@@ -114,7 +115,11 @@ class Validator
             };
 
             foreach ($ruleSet as $rule) {
-                $rule($value, $fail, $key, $this->values);
+                $command = $rule($value, $fail, $key, $this->values);
+
+                if ($command instanceof SkipValidationRules) {
+                    break;
+                }
 
                 if ($rule instanceof Sanitizer) {
                     $value = $rule->sanitize($value);

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -51,8 +51,6 @@ class Validator
      */
     public function __construct(array $ruleSets, array $values, array $labels = [])
     {
-        $this->validateRulesAndValues($ruleSets, $values);
-
         $validatedRules = [];
         foreach ($ruleSets as $key => $rule) {
             if (is_array($rule)) {
@@ -69,24 +67,6 @@ class Validator
         $this->ruleSets = $validatedRules;
         $this->values = $values;
         $this->labels = $labels;
-    }
-
-    /**
-     * Validates that all rules have a corresponding value with the same key.
-     *
-     * @unreleased
-     *
-     * @return void
-     */
-    private function validateRulesAndValues(array $rules, array $values)
-    {
-        $missingKeys = array_diff_key($rules, $values);
-
-        if (!empty($missingKeys)) {
-            Config::throwInvalidArgumentException(
-                "Missing values for rules: " . implode(', ', array_keys($missingKeys))
-            );
-        }
     }
 
     /**

--- a/tests/_support/Helper/TestCase.php
+++ b/tests/_support/Helper/TestCase.php
@@ -66,6 +66,36 @@ class TestCase extends Unit
         self::assertValidationRulePassed($rule, $value, $key, $values, false);
     }
 
+    public static function assertValidationRuleDoesReturnCommandInstance(
+        ValidationRule $rule,
+        string $commandClass,
+        $value = null,
+        string $key = '',
+        array $values = []
+    ) {
+        $fail = static function () {
+        };
+
+        $command = $rule($value, $fail, $key, $values);
+
+        self::assertInstanceOf($commandClass, $command);
+    }
+
+    public static function assertValidationRuleDoesNotReturnCommandInstance(
+        ValidationRule $rule,
+        string $commandClass,
+        $value = null,
+        string $key = '',
+        array $values = []
+    ) {
+        $fail = static function () {
+        };
+
+        $command = $rule($value, $fail, $key, $values);
+
+        self::assertNotInstanceOf($commandClass, $command);
+    }
+
     public static function assertIsIterable($actual, $message = '')
     {
         if (\function_exists('is_iterable') === true) {

--- a/tests/unit/Rules/NullableTest.php
+++ b/tests/unit/Rules/NullableTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StellarWP\Validation\Tests\Unit\Rules;
+
+use StellarWP\Validation\Commands\SkipValidationRules;
+use StellarWP\Validation\Rules\Nullable;
+use StellarWP\Validation\Tests\TestCase;
+
+class NullableTest extends TestCase
+{
+    /**
+     * @unreleased
+     */
+    public function testNullableValidation()
+    {
+        $rule = new Nullable();
+
+        // Passes when value is null and skips remaining tests
+        self::assertValidationRulePassed($rule, null, 'foo', ['foo' => null]);
+        self::assertValidationRuleDoesReturnCommandInstance($rule, SkipValidationRules::class, null);
+
+        // Passes on any other value but does not skip remaining tests
+        self::assertValidationRulePassed($rule, 'bar');
+        self::assertValidationRuleDoesNotReturnCommandInstance($rule, SkipValidationRules::class, 'bar');
+    }
+}

--- a/tests/unit/Rules/NullableTest.php
+++ b/tests/unit/Rules/NullableTest.php
@@ -18,7 +18,7 @@ class NullableTest extends TestCase
         $rule = new Nullable();
 
         // Passes when value is null and skips remaining tests
-        self::assertValidationRulePassed($rule, null, 'foo', ['foo' => null]);
+        self::assertValidationRulePassed($rule, null);
         self::assertValidationRuleDoesReturnCommandInstance($rule, SkipValidationRules::class, null);
 
         // Passes on any other value but does not skip remaining tests

--- a/tests/unit/Rules/OptionalTest.php
+++ b/tests/unit/Rules/OptionalTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StellarWP\Validation\Tests\Unit\Rules;
+
+use StellarWP\Validation\Commands\SkipValidationRules;
+use StellarWP\Validation\Rules\Optional;
+use StellarWP\Validation\Tests\TestCase;
+
+class OptionalTest extends TestCase
+{
+    /**
+     * @unreleased
+     */
+    public function testNullableValidation()
+    {
+        $rule = new Optional();
+
+        // Passes when value is null and skips remaining tests
+        self::assertValidationRulePassed($rule, null);
+        self::assertValidationRuleDoesReturnCommandInstance($rule, SkipValidationRules::class, null);
+
+        // Passes when value is empty string and skips remaining tests
+        self::assertValidationRulePassed($rule, '');
+        self::assertValidationRuleDoesReturnCommandInstance($rule, SkipValidationRules::class, '');
+
+        // Passes on any other value but does not skip remaining tests
+        self::assertValidationRulePassed($rule, 'bar');
+        self::assertValidationRuleDoesNotReturnCommandInstance($rule, SkipValidationRules::class, 'bar');
+    }
+}

--- a/tests/unit/ValidatorTest.php
+++ b/tests/unit/ValidatorTest.php
@@ -195,6 +195,22 @@ class ValidatorTest extends TestCase
         ], $validator->validated());
     }
 
+    public function testWithSkipValidationRulesSkipsRemainingRules()
+    {
+        $validator = new Validator([
+            'foo' => ['skip', 'required'],
+            'bar' => ['required'],
+        ], [
+            'foo' => '',
+            'bar' => 'bar',
+        ]);
+
+        self::assertSame([
+            'foo' => '',
+            'bar' => 'bar',
+        ], $validator->validated());
+    }
+
     /**
      * @unreleased
      */

--- a/tests/unit/ValidatorTest.php
+++ b/tests/unit/ValidatorTest.php
@@ -6,6 +6,7 @@ namespace StellarWP\Validation\Tests\Unit;
 
 use Closure;
 use InvalidArgumentException;
+use StellarWP\Validation\Commands\SkipValidationRules;
 use StellarWP\Validation\Config;
 use StellarWP\Validation\Contracts\Sanitizer;
 use StellarWP\Validation\Contracts\ValidationRule;
@@ -224,12 +225,31 @@ class ValidatorTest extends TestCase
                 $register = new ValidationRulesRegistrar();
                 $register->register(
                     MockRequiredRule::class,
-                    MockIntegerRule::class
+                    MockIntegerRule::class,
+                    MockSkipRule::class
                 );
 
                 return $register;
             }
         );
+    }
+}
+
+class MockSkipRule implements ValidationRule
+{
+    public static function id(): string
+    {
+        return 'skip';
+    }
+
+    public static function fromString(string $options = null): ValidationRule
+    {
+        return new self();
+    }
+
+    public function __invoke($value, Closure $fail, string $key, array $values): SkipValidationRules
+    {
+        return new SkipValidationRules();
     }
 }
 

--- a/tests/unit/ValidatorTest.php
+++ b/tests/unit/ValidatorTest.php
@@ -212,19 +212,6 @@ class ValidatorTest extends TestCase
     }
 
     /**
-     * @unreleased
-     */
-    public function testRulesWithoutValuesThrowsAnException()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Missing values for rules');
-
-        new Validator([
-            'foo' => ['required'],
-        ], []);
-    }
-
-    /**
      * Adds the validation register to the container, and adds a mock validation rule
      *
      * @unreleased

--- a/tests/unit/ValidatorTest.php
+++ b/tests/unit/ValidatorTest.php
@@ -195,6 +195,9 @@ class ValidatorTest extends TestCase
         ], $validator->validated());
     }
 
+    /**
+     * @unreleased
+     */
     public function testWithSkipValidationRulesSkipsRemainingRules()
     {
         $validator = new Validator([


### PR DESCRIPTION
This PR removes the `Validator::validateRulesandValues` method in favor of new rules. The validation method was deemed unnecessary, as values without rules are already omitted, and rules without values return a null value — the validator itself doesn't need to throw any exceptions as the end result is still safe data.

Example of data omitted without rules:

```php
$request = [
  'firstname' => 'Jason',
  'lastname' => 'Adams',
  'city' => 'Carlsbad',
];

$validator = new Validator([
  'firstname' => ['required'],
  'lastname' => ['required'],
], $request);

$expected = [
  'firstname' => 'Jason',
  'lastname' => 'Adams',
];
```

When reviewing the following, note that if a field is omitted entirely from the values, then its considered null. So both `optional` and `nullable` would work for omitted values.

## Optional
If the value is _null or an empty string_, then the remaining validation rules are skipped.

Example:

```php
$request = [
  'firstname' => 'Jason',
  'lastname' => 'Adams',
  'age' => ''
];

$validator = new Validator([
  'firstname' => ['required'],
  'lastname' => ['required'],
  'age' => ['optional', 'integer']
], $request);

$expected = [
  'firstname' => 'Jason',
  'lastname' => 'Adams',
  'age' => ''
];
```

## Nullable
If the value is _null_, then the remaining validation rules are skipped.

Example:

```php
$request = [
  'firstname' => 'Jason',
  'lastname' => 'Adams',
  'city' => null
];

$validator = new Validator([
  'firstname' => ['required'],
  'lastname' => ['required'],
  'city' => ['nullable', 'in:san diego'],
], $request);

$expected = [
  'firstname' => 'Jason',
  'lastname' => 'Adams',
  'city' => null,
];
```