### PR TITLE
Fix: Suppress PHP8.1+ notice for jsonSerialize

### DIFF
--- a/src/ValidationRuleSet.php
+++ b/src/ValidationRuleSet.php
@@ -255,6 +255,7 @@ class ValidationRuleSet implements IteratorAggregate, JsonSerializable
      *
      * @since 1.0.0
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $rules = [];


### PR DESCRIPTION
Currently, on PHP8.1 and later, you get the following deprecation notice:

```
( ! ) Deprecated: Return type of StellarWP\Validation\ValidationRuleSet::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in src/ValidationRuleSet.php on line 264
```

We can't add `mixed` return type to the function, because that would not work in PHP7, so we just add a suppression as recommended by the error message