### PR TITLE
Feature: Add In, InStrict, and DateTime validation rules

### DIFF
--- a/src/Rules/DateTime.php
+++ b/src/Rules/DateTime.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace StellarWP\Validation\Rules;
+
+use Closure;
+use DateTimeImmutable;
+use DateTimeInterface;
+use Exception;
+use StellarWP\Validation\Contracts\Sanitizer;
+use StellarWP\Validation\Contracts\ValidatesOnFrontEnd;
+use StellarWP\Validation\Contracts\ValidationRule;
+
+/**
+ * This rule validates that the given value is a valid date.
+ *
+ * @unreleased
+ */
+class DateTime implements ValidationRule, ValidatesOnFrontEnd, Sanitizer
+{
+    /**
+     * @var string|null
+     */
+    protected $format;
+
+    /**
+     * @unreleased
+     */
+    public static function id(): string
+    {
+        return 'dateTime';
+    }
+
+    /**
+     * @unreleased
+     */
+    public static function fromString(string $options = null): ValidationRule
+    {
+        return new static($options);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function __construct(string $format = null)
+    {
+        $this->format = $format;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function __invoke($value, Closure $fail, string $key, array $values)
+    {
+        if ($value instanceof DateTimeInterface) {
+            return;
+        }
+
+        $failedValidation = function () use ($fail) {
+            $fail(sprintf(__('%s must be a valid date', '%TEXTDOMAIN%'), '{field}'));
+        };
+
+        try {
+            if (!is_string($value) && !is_numeric($value)) {
+                $failedValidation();
+
+                return;
+            }
+
+            if ($this->format !== null) {
+                $date = \DateTime::createFromFormat($this->format, $value);
+                if ($date === false || $date->format($this->format) !== $value) {
+                    $failedValidation();
+
+                    return;
+                }
+            }
+
+            if (strtotime($value) === false) {
+                $failedValidation();
+
+                return;
+            }
+        } catch (Exception $exception) {
+            $failedValidation();
+
+            return;
+        }
+
+        $date = date_parse($value);
+
+        if (!checkdate($date['month'], $date['day'], $date['year'])) {
+            $failedValidation();
+        }
+    }
+
+    /**
+     * @unreleased
+     */
+    public function sanitize($value)
+    {
+        if ($value instanceof DateTimeInterface) {
+            return $value;
+        }
+
+        if ($this->format !== null) {
+            return DateTimeImmutable::createFromFormat($this->format, $value);
+        }
+
+        return new DateTimeImmutable($value);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function serializeOption()
+    {
+        return $this->format;
+    }
+
+}

--- a/src/Rules/In.php
+++ b/src/Rules/In.php
@@ -25,7 +25,7 @@ class In implements ValidationRule, ValidatesOnFrontEnd
     /**
      * @unreleased
      */
-    public function __construct(...$acceptedValues)
+    final public function __construct(...$acceptedValues)
     {
         if (empty($acceptedValues)) {
             Config::throwInvalidArgumentException('The In rule requires at least one value to be specified.');
@@ -49,7 +49,7 @@ class In implements ValidationRule, ValidatesOnFrontEnd
             Config::throwInvalidArgumentException('The In rule requires at least one value to be specified.');
         }
 
-        return new self(...$values);
+        return new static(...$values);
     }
 
     /**
@@ -57,7 +57,7 @@ class In implements ValidationRule, ValidatesOnFrontEnd
      */
     public function __invoke($value, Closure $fail, string $key, array $values)
     {
-        if (!in_array($value, $this->acceptedValues, true)) {
+        if (!in_array($value, $this->acceptedValues)) {
             $fail(sprintf(__('%s must be one of %s', '%TEXTDOMAIN%'), '{field}', implode(', ', $this->acceptedValues)));
         }
     }

--- a/src/Rules/In.php
+++ b/src/Rules/In.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace StellarWP\Validation\Rules;
+
+use Closure;
+use StellarWP\Validation\Config;
+use StellarWP\Validation\Contracts\ValidatesOnFrontEnd;
+use StellarWP\Validation\Contracts\ValidationRule;
+
+class In implements ValidationRule, ValidatesOnFrontEnd
+{
+    /**
+     * @var array
+     */
+    protected $acceptedValues;
+
+    /**
+     * @unreleased
+     */
+    public static function id(): string
+    {
+        return 'in';
+    }
+
+    /**
+     * @unreleased
+     */
+    public function __construct(...$acceptedValues)
+    {
+        if (empty($acceptedValues)) {
+            Config::throwInvalidArgumentException('The In rule requires at least one value to be specified.');
+        }
+
+        $this->acceptedValues = $acceptedValues;
+    }
+
+    /**
+     * @unreleased
+     */
+    public static function fromString(string $options = null): ValidationRule
+    {
+        if (empty(trim($options))) {
+            Config::throwInvalidArgumentException('The In rule requires at least one value to be specified.');
+        }
+
+        $values = explode(',', $options);
+
+        if (empty($values)) {
+            Config::throwInvalidArgumentException('The In rule requires at least one value to be specified.');
+        }
+
+        return new self(...$values);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function __invoke($value, Closure $fail, string $key, array $values)
+    {
+        if (!in_array($value, $this->acceptedValues, true)) {
+            $fail(sprintf(__('%s must be one of %s', '%TEXTDOMAIN%'), '{field}', implode(', ', $this->acceptedValues)));
+        }
+    }
+
+    /**
+     * @unreleased
+     */
+    public function serializeOption(): array
+    {
+        return $this->acceptedValues;
+    }
+}

--- a/src/Rules/InStrict.php
+++ b/src/Rules/InStrict.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace StellarWP\Validation\Rules;
+
+use Closure;
+
+class InStrict extends In
+{
+    /**
+     * @unreleased
+     */
+    public static function id(): string
+    {
+        return 'inStrict';
+    }
+
+    /**
+     * @unreleased
+     */
+    public function __invoke($value, Closure $fail, string $key, array $values)
+    {
+        if (!in_array($value, $this->acceptedValues, true)) {
+            $fail(sprintf(__('%s must be one of %s', '%TEXTDOMAIN%'), '{field}', implode(', ', $this->acceptedValues)));
+        }
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -9,6 +9,7 @@ use StellarWP\Validation\Rules\Email;
 use StellarWP\Validation\Rules\Exclude;
 use StellarWP\Validation\Rules\ExcludeIf;
 use StellarWP\Validation\Rules\ExcludeUnless;
+use StellarWP\Validation\Rules\In;
 use StellarWP\Validation\Rules\Integer;
 use StellarWP\Validation\Rules\Max;
 use StellarWP\Validation\Rules\Min;
@@ -30,6 +31,7 @@ class ServiceProvider
         Max::class,
         Size::class,
         Numeric::class,
+        In::class,
         Integer::class,
         Email::class,
         Currency::class,

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace StellarWP\Validation;
 
 use StellarWP\Validation\Rules\Currency;
+use StellarWP\Validation\Rules\DateTime;
 use StellarWP\Validation\Rules\Email;
 use StellarWP\Validation\Rules\Exclude;
 use StellarWP\Validation\Rules\ExcludeIf;
@@ -44,6 +45,7 @@ class ServiceProvider
         Optional::class,
         OptionalIf::class,
         OptionalUnless::class,
+        DateTime::class,
     ];
 
     /**

--- a/tests/unit/Rules/DateTimeTest.php
+++ b/tests/unit/Rules/DateTimeTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace StellarWP\Validation\Tests\Unit\Rules;
+
+use DateTime;
+use DateTimeImmutable;
+use StellarWP\Validation\Rules\DateTime as DateTimeRule;
+use StellarWP\Validation\Tests\TestCase;
+
+class DateTimeTest extends TestCase
+{
+    /**
+     * @unreleased
+     */
+    public function testShouldPassDateTimeInstance()
+    {
+        $rule = new DateTimeRule();
+
+        $this->assertValidationRulePassed($rule, new DateTime());
+        $this->assertValidationRulePassed($rule, new DateTimeImmutable());
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testShouldPassDateTimeString()
+    {
+        $rule = new DateTimeRule();
+
+        $this->assertValidationRulePassed($rule, '2018-01-01 00:00:00');
+        $this->assertValidationRulePassed($rule, '2018-01-01 00:00:00.000000');
+        $this->assertValidationRulePassed($rule, '2018-01-01T00:00:00+00:00');
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testShouldFailRelativeDateTimeString()
+    {
+        $rule = new DateTimeRule();
+
+        $this->assertValidationRuleFailed($rule, 'now');
+        $this->assertValidationRuleFailed($rule, 'tomorrow');
+        $this->assertValidationRuleFailed($rule, 'yesterday');
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testShouldFailInvalidDateTimeStringValues()
+    {
+        $rule = new DateTimeRule();
+
+        $this->assertValidationRuleFailed($rule, true);
+        $this->assertValidationRuleFailed($rule, []);
+        $this->assertValidationRuleFailed($rule, 'abc');
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testShouldPassDateTimeStringWithFormat()
+    {
+        $rule = new DateTimeRule('Y-m-d H:i:s');
+
+        $this->assertValidationRulePassed($rule, '2018-01-01 00:00:00');
+        $this->assertValidationRuleFailed($rule, '2018-01-01 00:00:00.000000');
+        $this->assertValidationRuleFailed($rule, '2018-01-01T00:00:00+00:00');
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testShouldReturnSameDateTimeInstanceWhenSanitizing()
+    {
+        $rule = new DateTimeRule();
+
+        $date = new DateTimeImmutable();
+        $this->assertSame($date, $rule->sanitize($date));
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testShouldReturnDateTimeInstanceWhenSanitizingDateTimeString()
+    {
+        $rule = new DateTimeRule();
+
+        $date = new DateTimeImmutable();
+        $this->assertEquals(
+            $date->format('Y-m-d H:i:s'),
+            $rule->sanitize($date->format('Y-m-d H:i:s'))->format('Y-m-d H:i:s')
+        );
+    }
+}

--- a/tests/unit/Rules/InStrictTest.php
+++ b/tests/unit/Rules/InStrictTest.php
@@ -1,32 +1,32 @@
 <?php
 
-namespace unit\Rules;
+namespace StellarWP\Validation\Tests\Unit\Rules;
 
 use InvalidArgumentException;
-use StellarWP\Validation\Rules\In;
+use StellarWP\Validation\Rules\InStrict;
 use StellarWP\Validation\Tests\TestCase;
 
-class InTest extends TestCase
+class InStrictTest extends TestCase
 {
     /**
      * @unreleased
      */
-    public function testShouldAllowEquivalentValuesInArray()
+    public function testShouldAllowStrictlyEqualValuesInArray()
     {
-        $rule = new In('foo', 1);
+        $rule = new InStrict('foo', 1);
 
         $this->assertValidationRulePassed($rule, 'foo');
         $this->assertValidationRulePassed($rule, 1);
-        $this->assertValidationRulePassed($rule, '1');
     }
 
     /**
      * @unreleased
      */
-    public function testShouldFailValuesNotInArray()
+    public function testShouldFailStrictlyUnequalValues()
     {
-        $rule = new In('foo', 1);
+        $rule = new InStrict('foo', 1);
 
+        $this->assertValidationRuleFailed($rule, '1');
         $this->assertValidationRuleFailed($rule, 'bar');
         $this->assertValidationRuleFailed($rule, 2);
         $this->assertValidationRuleFailed($rule, false);
@@ -37,11 +37,11 @@ class InTest extends TestCase
      */
     public function testShouldCreateRuleFromCommaDelimitedList()
     {
-        $rule = In::fromString('foo,1');
+        $rule = InStrict::fromString('foo,1');
 
         $this->assertValidationRulePassed($rule, 'foo');
-        $this->assertValidationRulePassed($rule, 1);
         $this->assertValidationRulePassed($rule, '1');
+        $this->assertValidationRuleFailed($rule, 1);
         $this->assertValidationRuleFailed($rule, 'qux');
     }
 
@@ -52,7 +52,7 @@ class InTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        In::fromString('');
+        InStrict::fromString('');
     }
 
     /**
@@ -62,7 +62,7 @@ class InTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        new In();
+        new InStrict();
     }
 
     /**
@@ -70,7 +70,7 @@ class InTest extends TestCase
      */
     public function testSerializeOptionShouldRetunValuesArray()
     {
-        $rule = new In('foo', 'bar', 'baz');
+        $rule = new InStrict('foo', 'bar', 'baz');
         $this->assertEquals(['foo', 'bar', 'baz'], $rule->serializeOption());
     }
 }

--- a/tests/unit/Rules/InTest.php
+++ b/tests/unit/Rules/InTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace unit\Rules;
+
+use InvalidArgumentException;
+use StellarWP\Validation\Rules\In;
+use StellarWP\Validation\Tests\TestCase;
+
+class InTest extends TestCase
+{
+    /**
+     * @unreleased
+     */
+    public function testShouldAllowValuesInArray()
+    {
+        $rule = new In('foo', 1, true);
+
+        $this->assertValidationRulePassed($rule, 'foo');
+        $this->assertValidationRulePassed($rule, 1);
+        $this->assertValidationRulePassed($rule, true);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testShouldFailValuesNotInArray()
+    {
+        $rule = new In('foo', 1, true);
+
+        $this->assertValidationRuleFailed($rule, 'bar');
+        $this->assertValidationRuleFailed($rule, '1');
+        $this->assertValidationRuleFailed($rule, 2);
+        $this->assertValidationRuleFailed($rule, false);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testShouldCreateRuleFromCommaDelimitedList()
+    {
+        $rule = In::fromString('foo,bar');
+
+        $this->assertValidationRulePassed($rule, 'foo');
+        $this->assertValidationRulePassed($rule, 'bar');
+        $this->assertValidationRuleFailed($rule, 'qux');
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testFromStringShouldRequireValues()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        In::fromString('');
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testShouldThrowInvalidExceptionWithoutValues()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new In();
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testSerializeOptionShouldRetunValuesArray()
+    {
+        $rule = new In('foo', 'bar', 'baz');
+        $this->assertEquals(['foo', 'bar', 'baz'], $rule->serializeOption());
+    }
+}


### PR DESCRIPTION
Resolves #1 

This adds the `In` and `DateTime` validation rules.

### In Rule
The `In` rule limits a value to a given set of values:
```php
'agree' => ['in:yes,no'],
'rating' => [new In(1, 2, 3, 4, 5)]
```

The only thing I'm going back and forth on is whether value checking should be strict or not. If it's not strict, then `in:1,2,3` wouldn't match integer values of 1, 2, 3. That seems counterintuitive, but is only an issue when converting from string values. Still, that's encouraged behavior. Looking at the [Laravel In rule](https://github.com/laravel/framework/blob/master/src/Illuminate/Validation/Concerns/ValidatesAttributes.php#L1270-L1283), it's not strict. If not strict, then perhaps the `In` constructor should not be variadic and have a second, `$strict` parameter: `new In([1, 2, 3], true)` — which is false by default. Open to thoughts!

### DateTime Rule
The `DateTime` rule validates that a given value is a valid date and/or time, and then sanitizes it as a `DateTimeImmutable`:
```php
'flexibleDateTimeFormat' => 'dateTime',
'specificDateTimeFormat' => 'dateTime:Y-m-d H:i:s'
```

Note that relative date formats _never_ pass. So values like `now` or `+1 day` will not pass validation.

If the value passed is a `DateTimeInterface` instance, then it passes and is directly passed back. Otherwise, the value is parsed to a `DateTimeImmutable` (using the optional format if provided), and the new instance is returned.

It may be too opinionated to return a `DateTimeImmutable` over a `DateTime`. I'm open to feedback here as well.