### PR TITLE
Feature: add methods for replacing and prepending rules

### DIFF
--- a/src/ValidationRuleSet.php
+++ b/src/ValidationRuleSet.php
@@ -133,6 +133,8 @@ class ValidationRuleSet implements IteratorAggregate, JsonSerializable
     /**
      * Finds and returns the validation rule by id. Does not work for Closure rules.
      *
+     * @since 1.0.0
+     *
      * @return ValidationRule|null
      */
     public function getRule(string $rule)

--- a/tests/unit/ValidationRuleSetTest.php
+++ b/tests/unit/ValidationRuleSetTest.php
@@ -118,14 +118,22 @@ class ValidationRuleSetTest extends TestCase
 
     public function testReplacingARule()
     {
+        // Replace if rule exists
         $rules = new ValidationRuleSet($this->getMockRulesRegister());
         $rules->rules('required', 'size:5');
-        $rules->replaceRule('size', new Size(10));
 
+        self::assertTrue($rules->replaceRule('size', new Size(10)));
         self::assertCount(2, $rules);
         self::assertTrue($rules->hasRule('required'));
         self::assertTrue($rules->hasRule('size'));
         self::assertEquals(10, $rules->getRule('size')->getSize());
+
+        // Do not replace if rule does not exist
+        $rules = new ValidationRuleSet($this->getMockRulesRegister());
+        $rules->rules('required');
+
+        self::assertFalse($rules->replaceRule('size', new Size(10)));
+        self::assertCount(1, $rules);
     }
 
     public function testConditionallyReplacingOrAppendingARule()
@@ -133,8 +141,9 @@ class ValidationRuleSetTest extends TestCase
         // Replace if rule exists
         $rules = new ValidationRuleSet($this->getMockRulesRegister());
         $rules->rules('required', 'size:5');
-        $rules->replaceOrAppendRule('size', new Size(10));
 
+
+        self::assertTrue($rules->replaceOrAppendRule('size', new Size(10)));
         self::assertCount(2, $rules);
         self::assertTrue($rules->hasRule('required'));
         self::assertTrue($rules->hasRule('size'));
@@ -143,8 +152,8 @@ class ValidationRuleSetTest extends TestCase
         // Append if rule does not exist
         $rules = new ValidationRuleSet($this->getMockRulesRegister());
         $rules->rules('required');
-        $rules->replaceOrAppendRule('size', new Size(10));
 
+        self::assertFalse($rules->replaceOrAppendRule('size', new Size(10)));
         self::assertCount(2, $rules);
         self::assertTrue($rules->hasRule('required'));
         self::assertTrue($rules->hasRule('size'));
@@ -156,8 +165,8 @@ class ValidationRuleSetTest extends TestCase
         // Replace if rule exists
         $rules = new ValidationRuleSet($this->getMockRulesRegister());
         $rules->rules('required', 'size:5');
-        $rules->replaceOrPrependRule('size', new Size(10));
 
+        self::AssertTrue($rules->replaceOrPrependRule('size', new Size(10)));
         self::assertCount(2, $rules);
         self::assertTrue($rules->hasRule('required'));
         self::assertTrue($rules->hasRule('size'));
@@ -166,8 +175,8 @@ class ValidationRuleSetTest extends TestCase
         // Prepend if rule does not exist
         $rules = new ValidationRuleSet($this->getMockRulesRegister());
         $rules->rules('required');
-        $rules->replaceOrPrependRule('size', new Size(10));
 
+        self::assertFalse($rules->replaceOrPrependRule('size', new Size(10)));
         self::assertCount(2, $rules);
         self::assertTrue($rules->hasRule('required'));
         self::assertTrue($rules->hasRule('size'));

--- a/tests/unit/ValidationRuleSetTest.php
+++ b/tests/unit/ValidationRuleSetTest.php
@@ -52,6 +52,9 @@ class ValidationRuleSetTest extends TestCase
         self::assertCount(1, $rules);
     }
 
+    /**
+     * @unreleased
+     */
     public function testPrependingARule()
     {
         $rules = new ValidationRuleSet($this->getMockRulesRegister());
@@ -60,10 +63,13 @@ class ValidationRuleSetTest extends TestCase
 
         self::assertCount(2, $rules);
         self::assertInstanceOf(Required::class, $rules->getRule('required'));
-        self::assertJsonStringEqualsJsonString(json_encode([
-            'required' => true,
-            'size' => 5,
-        ]), json_encode($rules));
+        self::assertJsonStringEqualsJsonString(
+            json_encode([
+                'required' => true,
+                'size' => 5,
+            ]),
+            json_encode($rules)
+        );
     }
 
     /**
@@ -77,6 +83,22 @@ class ValidationRuleSetTest extends TestCase
         self::assertTrue($rules->hasRule('required'));
         self::assertTrue($rules->hasRule('size'));
         self::assertFalse($rules->hasRule('email'));
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testCheckingHasAnyRules()
+    {
+        // True if it has rules
+        $rules = new ValidationRuleSet($this->getMockRulesRegister());
+        $rules->rules('required', 'size:5');
+
+        self::assertTrue($rules->hasRules());
+
+        // False if it has no rules
+        $rules = new ValidationRuleSet($this->getMockRulesRegister());
+        self::assertFalse($rules->hasRules());
     }
 
     /**
@@ -116,6 +138,9 @@ class ValidationRuleSetTest extends TestCase
         self::assertFalse($rules->hasRule('required'));
     }
 
+    /**
+     * @unreleased
+     */
     public function testReplacingARule()
     {
         // Replace if rule exists
@@ -136,6 +161,9 @@ class ValidationRuleSetTest extends TestCase
         self::assertCount(1, $rules);
     }
 
+    /**
+     * @unreleased
+     */
     public function testConditionallyReplacingOrAppendingARule()
     {
         // Replace if rule exists
@@ -160,6 +188,9 @@ class ValidationRuleSetTest extends TestCase
         self::assertEquals(10, $rules->getRule('size')->getSize());
     }
 
+    /**
+     * @unreleased
+     */
     public function testConditionallyReplacingOrPrependingRules()
     {
         // Replace if rule exists


### PR DESCRIPTION
Presently it's only possible to append validation rules and remove rules. In GiveWP we have a scenario where we want to prepend a `ExcludeUnless` rule to a given ruleset. Actually, we want to replace the rule if it already exists and prepend if it doesn't.

This led me to add some useful functions for prepending and replacing rules within a `ValidationRuleSet`:
- `prependRule`
- `replaceRule` — replaces a rule with a given ID at the same position in the rule set
- `replaceOrAppendRule`
- `replaceOrPrependRule`

The last two, of course, are just to be declarative and helpful.