### PR TITLE
Fix: boolean rule to check if value is a boolean

### DIFF
--- a/src/Rules/Boolean.php
+++ b/src/Rules/Boolean.php
@@ -7,6 +7,8 @@ use StellarWP\Validation\Contracts\Sanitizer;
 use StellarWP\Validation\Contracts\ValidatesOnFrontEnd;
 use StellarWP\Validation\Contracts\ValidationRule;
 
+use const FILTER_NULL_ON_FAILURE;
+
 class Boolean implements ValidationRule, ValidatesOnFrontEnd, Sanitizer
 {
     /**
@@ -32,12 +34,13 @@ class Boolean implements ValidationRule, ValidatesOnFrontEnd, Sanitizer
     /**
      * {@inheritDoc}
      *
+     * @unreleased add is_bool check and FILTER_NULL_ON_FAILURE flag to prevent false positives
      * @since 1.4.0
      */
     public function __invoke($value, Closure $fail, string $key, array $values)
     {
-        if (!filter_var($value, FILTER_VALIDATE_BOOLEAN)) {
-            $fail(sprintf(__('%s must be an boolean', '%TEXTDOMAIN%'), '{field}'));
+        if (!is_bool(filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE))) {
+            $fail(sprintf(__('%s must be a boolean', '%TEXTDOMAIN%'), '{field}'));
         }
     }
 

--- a/tests/unit/Rules/BooleanTest.php
+++ b/tests/unit/Rules/BooleanTest.php
@@ -36,15 +36,16 @@ class BooleanTest extends TestCase
             ['true', true],
             ['yes', true],
             ['on', true],
+            [false, true],
+            [0, true],
+            ['0', true],
+            ['false', true],
+            ['no', true],
+            ['off', true],
 
             // values that fail
-            [false, false],
-            [0, false],
-            ['0', false],
-            ['false', false],
-            ['no', false],
-            ['off', false],
             ['abc', false],
+            ['123', false],
         ];
     }
 


### PR DESCRIPTION
Resolves: https://github.com/stellarwp/validation/issues/16

This prevents the boolean rule from returning false positives by adding an `is_bool` check and `FILTER_NULL_ON_FAILURE` flag to `filter_var`.

After using `filter_var` to determine the boolean value we use `is_bool` to check if the value is a boolean.  With the addition of the filter flag `FILTER_NULL_ON_FAILURE`,`filter_var` will now return null on failure - causing `is_bool` to return false.