### PR TITLE
Fix: addresses implicit nullability for PHP 8.4 compatibility

### DIFF
--- a/src/Contracts/ValidationRule.php
+++ b/src/Contracts/ValidationRule.php
@@ -25,7 +25,7 @@ interface ValidationRule
      *
      * @since 1.0.0
      */
-    public static function fromString(string $options = null): ValidationRule;
+    public static function fromString(?string $options = null): ValidationRule;
 
     /**
      * The invokable method used to validate the value. If the value is invalid, the fail callback should be invoked

--- a/src/Rules/Abstracts/ConditionalRule.php
+++ b/src/Rules/Abstracts/ConditionalRule.php
@@ -39,7 +39,7 @@ abstract class ConditionalRule implements ValidationRule, ValidatesOnFrontEnd
      *
      * @since 1.2.0
      */
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         if (empty($options)) {
             Config::throwInvalidArgumentException(static::class . ' rule requires at least one condition');

--- a/src/Rules/Boolean.php
+++ b/src/Rules/Boolean.php
@@ -26,7 +26,7 @@ class Boolean implements ValidationRule, ValidatesOnFrontEnd, Sanitizer
      *
      * @since 1.4.0
      */
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         return new self();
     }

--- a/src/Rules/Currency.php
+++ b/src/Rules/Currency.php
@@ -25,7 +25,7 @@ class Currency implements ValidationRule, ValidatesOnFrontEnd
      *
      * @since 1.0.0
      */
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         return new self();
     }

--- a/src/Rules/DateTime.php
+++ b/src/Rules/DateTime.php
@@ -33,7 +33,7 @@ class DateTime implements ValidationRule, ValidatesOnFrontEnd, Sanitizer
     /**
      * @since 1.2.0
      */
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         return new static($options);
     }
@@ -41,7 +41,7 @@ class DateTime implements ValidationRule, ValidatesOnFrontEnd, Sanitizer
     /**
      * @since 1.2.0
      */
-    public function __construct(string $format = null)
+    public function __construct(?string $format = null)
     {
         $this->format = $format;
     }

--- a/src/Rules/Email.php
+++ b/src/Rules/Email.php
@@ -28,7 +28,7 @@ class Email implements ValidationRule, ValidatesOnFrontEnd
      *
      * @since 1.0.0
      */
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         return new self();
     }

--- a/src/Rules/Exclude.php
+++ b/src/Rules/Exclude.php
@@ -30,7 +30,7 @@ class Exclude implements ValidationRule
      *
      * @since 1.2.0
      */
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         return new self();
     }

--- a/src/Rules/In.php
+++ b/src/Rules/In.php
@@ -37,7 +37,7 @@ class In implements ValidationRule, ValidatesOnFrontEnd
     /**
      * @since 1.2.0
      */
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         if (empty(trim($options))) {
             Config::throwInvalidArgumentException('The In rule requires at least one value to be specified.');

--- a/src/Rules/Integer.php
+++ b/src/Rules/Integer.php
@@ -22,7 +22,7 @@ class Integer implements ValidationRule, ValidatesOnFrontEnd, Sanitizer
     /**
      * @inheritDoc
      */
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         return new self();
     }

--- a/src/Rules/Max.php
+++ b/src/Rules/Max.php
@@ -47,7 +47,7 @@ class Max implements ValidationRule, ValidatesOnFrontEnd
      *
      * @since 1.0.0
      */
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         if (!is_numeric($options)) {
             Config::throwInvalidArgumentException('Max validation rule requires a numeric value');

--- a/src/Rules/Min.php
+++ b/src/Rules/Min.php
@@ -47,7 +47,7 @@ class Min implements ValidationRule, ValidatesOnFrontEnd
      *
      * @since 1.0.0
      */
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         if (!is_numeric($options)) {
             Config::throwInvalidArgumentException('Min validation rule requires a numeric value');

--- a/src/Rules/Nullable.php
+++ b/src/Rules/Nullable.php
@@ -28,7 +28,7 @@ class Nullable implements ValidationRule, ValidatesOnFrontEnd
     /**
      * @since 1.1.0
      */
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         return new self();
     }

--- a/src/Rules/Numeric.php
+++ b/src/Rules/Numeric.php
@@ -25,7 +25,7 @@ class Numeric implements ValidationRule, ValidatesOnFrontEnd
      *
      * @since 1.0.0
      */
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         return new self();
     }

--- a/src/Rules/Optional.php
+++ b/src/Rules/Optional.php
@@ -27,7 +27,7 @@ class Optional implements ValidationRule, ValidatesOnFrontEnd
     /**
      * @since 1.1.0
      */
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         return new self();
     }

--- a/src/Rules/Required.php
+++ b/src/Rules/Required.php
@@ -21,7 +21,7 @@ class Required implements ValidationRule, ValidatesOnFrontEnd
     /**
      * @inheritDoc
      */
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         return new self();
     }

--- a/src/Rules/Size.php
+++ b/src/Rules/Size.php
@@ -47,7 +47,7 @@ class Size implements ValidationRule, ValidatesOnFrontEnd
      *
      * @since 1.0.0
      */
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         if (!is_numeric($options)) {
             Config::throwInvalidArgumentException('Size validation rule requires a numeric value');

--- a/tests/unit/ValidatorTest.php
+++ b/tests/unit/ValidatorTest.php
@@ -277,7 +277,7 @@ class MockSkipRule implements ValidationRule
         return 'skip';
     }
 
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         return new self();
     }
@@ -301,7 +301,7 @@ class MockRequiredRule implements ValidationRule
     /**
      * @inheritDoc
      */
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         return new self();
     }
@@ -330,7 +330,7 @@ class MockIntegerRule implements ValidationRule, Sanitizer
     /**
      * @inheritDoc
      */
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         return new self();
     }
@@ -361,7 +361,7 @@ class MockExcludeRule implements ValidationRule
         return 'exclude';
     }
 
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         return new self();
     }


### PR DESCRIPTION
As of PHP 8.4 [parameters cannot be implicitly nullable](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types). This addresses that by explicitly making said parameters nullable. Note that this is technically not a breaking signature change since any 3rd party code implementing the `ValidationRule` interface is covariant on the parameter.